### PR TITLE
feat: enable caching for CLI tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Use this .gitignore file as the `--ignore-path` for ESLint and Prettier as well,
 # since everything that's excluded from repo source control shouldn't be checked.
+.caches/
 coverage/
 lib/
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
 	"material-icon-theme.files.associations": {
 		"src/semantic-release.config.ts": "semantic-release"
 	},
+	"material-icon-theme.folders.associations": {
+		".caches": "Temp"
+	},
 	"prettier.configPath": "lib/prettier.config.js",
 	"prettier.ignorePath": ".gitignore"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
 		"pre-push": "shellscript"
 	},
 	"material-icon-theme.files.associations": {
+		".caches/.prettiercache": "Prettier",
 		"src/semantic-release.config.ts": "semantic-release"
 	},
 	"material-icon-theme.folders.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
 		"src/semantic-release.config.ts": "semantic-release"
 	},
 	"material-icon-theme.folders.associations": {
-		".caches": "Temp"
+		".caches": "Temp",
+		".caches/.jestcache": "Test"
 	},
 	"prettier.configPath": "lib/prettier.config.js",
 	"prettier.ignorePath": ".gitignore"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"init": "git config core.hooksPath ./.githooks/ && npm install && npm run validate",
 		"lint.js-ts": "eslint --config ./lib/eslint.config.cjs --cache --cache-location ./.caches/.eslintcache --ignore-path ./.gitignore",
 		"prepublishOnly": "npm run build",
-		"test.unit": "jest --config ./lib/jest.config.js",
+		"test.unit": "jest --config ./lib/jest.config.js --cache",
 		"test.unit.coverage": "npm run test.unit -- --coverage",
 		"test.unit.watch": "npm run test.unit -- --watch --coverage --collectCoverageFrom=",
 		"validate": "npm run build && npm run check && npm run test.unit.coverage"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"githooks.pre-push": "npm run validate",
 		"// init": "Initialize repo by: 1) configuring Git hooks, 2) installing dependencies, and 3) validating the codebase.",
 		"init": "git config core.hooksPath ./.githooks/ && npm install && npm run validate",
-		"lint.js-ts": "eslint --config ./lib/eslint.config.cjs --ignore-path ./.gitignore",
+		"lint.js-ts": "eslint --config ./lib/eslint.config.cjs --cache --cache-location ./.caches/.eslintcache --ignore-path ./.gitignore",
 		"prepublishOnly": "npm run build",
 		"test.unit": "jest --config ./lib/jest.config.js",
 		"test.unit.coverage": "npm run test.unit -- --coverage",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"fix": "npm-run-all2 --parallel fix.*",
 		"fix.format": "npm run format -- --write ./",
 		"fix.lint.js-ts": "npm run lint.js-ts -- --fix ./",
-		"format": "prettier --config ./lib/prettier.config.js --ignore-path ./.gitignore",
+		"format": "prettier --config ./lib/prettier.config.js --cache --cache-location ./.caches/.prettiercache --ignore-path ./.gitignore",
 		"// ghaw": "Use the `act` tool to test GitHub Actions workflows locally.",
 		"ghaw.release": "act --input DRY_RUN=true --secret OP_SERVICE_ACCOUNT_TOKEN --workflows .github/workflows/release.yaml",
 		"ghaw.validate": "act --workflows .github/workflows/validate.yaml",

--- a/src/jest.config.test.ts
+++ b/src/jest.config.test.ts
@@ -39,6 +39,7 @@ describe("it exports a configuration object and the most important config option
 
 		expect(typeof jestConfig).toEqual("object");
 
+		expect(jestConfig.cacheDirectory).toEqual("<rootDir>/.caches/.jestcache/");
 		expect(jestConfig.coverageProvider).toEqual("v8");
 		expect(jestConfig.transform?.[".(js|jsx|ts|tsx)"]).toEqual("@swc/jest");
 		expect(jestConfig.verbose).toBe(true);

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -38,6 +38,11 @@ export const makeJestConfig = async (): Promise<Config> => {
 	// Note: The `cjs` and `cts` file extensions are included in the Jest config because this repo has some tools
 	// that only work with CommonJS `module.exports = {}` objects, and these files need to be unit tested too.
 	return {
+		// Excerpt from https://jestjs.io/docs/configuration#cachedirectory-string:
+		// > The directory where Jest should store its cached dependency information.
+		// > Jest attempts to scan your dependency tree once (up-front) and cache it in order to ease some of the filesystem churn that
+		// > needs to happen while running tests. This config option lets you customize where Jest stores that cache data on disk.
+		cacheDirectory: "<rootDir>/.caches/.jestcache/",
 		// Specify `collectCoverageFrom` to ensure that Jest collects test coverage for all JavaScript and TypeScript files.
 		// Excerpt from https://jestjs.io/docs/configuration#collectcoveragefrom-array:
 		// > An array of glob patterns indicating a set of files for which coverage information should be collected.


### PR DESCRIPTION
## Summary

- Creates the Git-ignored `.caches/` directory to store all cache-related directories and files.
- Enables caching for all CLI tools that support the `--cache` flag (ESLint, Jest, and Prettier).