### PR TITLE
feat: fix and improve husky script for Git hooks

### DIFF
--- a/.githooks/_/README.md
+++ b/.githooks/_/README.md
@@ -1,0 +1,31 @@
+# .githooks/\_/husky.sh
+
+## Summary
+
+- Description: husky.sh shell script adapted from the original husky template for Git hooks.
+- Documentation: https://typicode.github.io/husky/
+- Repository: https://github.com/typicode/husky
+- Version: 9.0.11
+
+## Upgrading the husky version
+
+1. Run the following commands:
+
+```sh
+npm install --save-dev --save-exact husky@latest
+npx husky init
+npm run init
+```
+
+2. Compare the Git diffs between the following files and incorporate the changes from the former into the latter:
+
+| Former               | Latter                  |
+| :------------------- | :---------------------- |
+| .husky/\_/h          | .githooks/\_/husky.sh   |
+| .husky/\_/commit-msg | .githooks/\_/commit-msg |
+| .husky/\_/pre-commit | .githooks/\_/pre-commit |
+| .husky/\_/pre-push   | .githooks/\_/pre-push   |
+
+3. Delete the .husky/ directory.
+
+4. Commit the changes to the files in the .githooks/ directory.

--- a/.githooks/_/husky.sh
+++ b/.githooks/_/husky.sh
@@ -17,12 +17,12 @@
 #
 # 2. Compare the Git diffs between the following files and incorporate the changes from the former into the latter:
 #
-#    | Former                 | Latter              |
-#    | :--------------------- | :------------------ |
-#    | .githooks/_husky.sh    | .husky/_/h          |
-#    | .githooks/_/commit-msg | .husky/_/commit-msg |
-#    | .githooks/_/pre-commit | .husky/_/pre-commit |
-#    | .githooks/_/pre-push   | .husky/_/pre-push   |
+#    | Former              | Latter                 |
+#    | :------------------ | :--------------------- |
+#    | .husky/_/h          | .githooks/_/husky.sh   |
+#    | .husky/_/commit-msg | .githooks/_/commit-msg |
+#    | .husky/_/pre-commit | .githooks/_/pre-commit |
+#    | .husky/_/pre-push   | .githooks/_/pre-push   |
 #
 # 3. Delete the .husky/ directory.
 #

--- a/.githooks/_/husky.sh
+++ b/.githooks/_/husky.sh
@@ -28,22 +28,37 @@
 #
 # 4. Commit the changes to the files in the .githooks/ directory.
 
+# If the $HUSKY environment variable is set to 2 then make the shell
+# print the commands (and their arguments) as they're executed.
 [ "$HUSKY" = "2" ] && set -x
+# h = the name of the Git hook (ex: commit-msg)
 h="${0##*/}"
+# s = the path of the Git hook script (ex: .githooks/commit-msg)
 s="${0%/*/*}/$h"
 
-[ ! -f "$s" ] && exit 0
+# Only log the script if it doesn't contain the ".githooks/_/" substring.
+if [[ $s != *.githooks/_/* ]]; then
+  echo "🪝-ℹ️ Executing Git hook script: $s"
+fi
 
+# Check if the script exists; if it doesn't exist, log a warning and terminate with a zero status code.
+[ ! -f "$s" ] && echo "🪝-⚠️ Git hook script not found: $s" && exit 0
+
+# Check if the following files exist; if they do exist, source them.
 for f in "${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh" "$HOME/.huskyrc"; do
 	# shellcheck disable=SC1090
 	[ -f "$f" ] && . "$f"
 done
 
+# If the $HUSKY environment variable is set to 0 then terminate with a zero status code.
 [ "${HUSKY-}" = "0" ] && exit 0
 
+# Execute the Git hook script file along with its passed arguments.
 sh -e "$s" "$@"
+# Store the exit status code.
 c=$?
 
-[ $c != 0 ] && echo "husky - $h script failed (code $c)"
-[ $c = 127 ] && echo "husky - command not found in PATH=$PATH"
+# If the Git hook script exits with a non-zero status code then log the error(s) and exit with the status code.
+[ $c != 0 ] && echo "🐶-❌ husky error - $h script failed (code $c)"
+[ $c = 127 ] && echo "🐶-❌ husky error - command not found in PATH=$PATH"
 exit $c

--- a/.githooks/_/husky.sh
+++ b/.githooks/_/husky.sh
@@ -1,32 +1,6 @@
 #!/usr/bin/env sh
 
-# Description   - husky.sh shell script adapted from the original husky template for Git hooks.
-# Documentation - https://typicode.github.io/husky/
-# Repository    - https://github.com/typicode/husky
-# Version       - 9.0.11
-#
-# To upgrade the husky version:
-#
-# 1. Run the following commands:
-#
-#    ```sh
-#    npm install --save-dev --save-exact husky@latest
-#    npx husky init
-#    npm run init
-#    ```
-#
-# 2. Compare the Git diffs between the following files and incorporate the changes from the former into the latter:
-#
-#    | Former              | Latter                 |
-#    | :------------------ | :--------------------- |
-#    | .husky/_/h          | .githooks/_/husky.sh   |
-#    | .husky/_/commit-msg | .githooks/_/commit-msg |
-#    | .husky/_/pre-commit | .githooks/_/pre-commit |
-#    | .husky/_/pre-push   | .githooks/_/pre-push   |
-#
-# 3. Delete the .husky/ directory.
-#
-# 4. Commit the changes to the files in the .githooks/ directory.
+# Related file: .githooks/_/README.md
 
 # If the $HUSKY environment variable is set to 2 then make the shell
 # print the commands (and their arguments) as they're executed.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"githooks.pre-commit": "npm run build && lint-staged --config ./lib/lint-staged.config.js --relative",
 		"githooks.pre-push": "npm run validate",
 		"// init": "Initialize repo by: 1) configuring Git hooks, 2) installing dependencies, and 3) validating the codebase.",
-		"init": "git config core.hooksPath ./.githooks/ && npm install && npm run validate",
+		"init": "git config core.hooksPath ./.githooks/_/ && npm install && npm run validate",
 		"lint.js-ts": "eslint --config ./lib/eslint.config.cjs --cache --cache-location ./.caches/.eslintcache --ignore-path ./.gitignore",
 		"prepublishOnly": "npm run build",
 		"test.unit": "jest --config ./lib/jest.config.js --cache",


### PR DESCRIPTION
## Summary

- The NPM `init` script had an incorrect path for the Git hooks scripts; it was using the `git config core.hooksPath ./.githooks/` command, whereas the correct command is `git config core.hooksPath ./.githooks/_/` since that's where the `husky.sh` script is located.
- The `husky.sh` script has been augmented with better log and error messages, and the "upgrading the husky version" steps have been moved out from script comments and into their own README.md file.