### PR TITLE
feat: enable NPM provenance statements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
         description: Perform a dry-run of the release; defaults to `false`, but set to `true` in the `github/release` NPM script.
         default: false
         type: boolean
-# Excerpt from https://github.com/semantic-release/npm#npm-provenance-on-github-actions
+# Excerpt from https://github.com/semantic-release/npm#npm-provenance-on-github-actions:
 # > For package provenance to be signed on the GitHub Actions CI the following permission is required to be enabled on the job:
 permissions:
   # > `id-token: write` enables use of OIDC for npm provenance.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
         description: Perform a dry-run of the release; defaults to `false`, but set to `true` in the `github/release` NPM script.
         default: false
         type: boolean
+# Excerpt from https://github.com/semantic-release/npm#npm-provenance-on-github-actions
+# > For package provenance to be signed on the GitHub Actions CI the following permission is required to be enabled on the job:
+permissions:
+  # > `id-token: write` enables use of OIDC for npm provenance.
+  id-token: write
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/__tests__/packageJSON.test.ts
+++ b/__tests__/packageJSON.test.ts
@@ -29,6 +29,10 @@ test("the most important configuration options are correct", () => {
 		"tsconfig.build.json",
 		"tsconfig.json",
 	]);
+	// Excerpt from https://docs.npmjs.com/generating-provenance-statements:
+	// > You can generate provenance statements for the packages you publish. This allows you to publicly establish where
+	// > a package was built and who published a package, which can increase supply-chain security for your packages.
+	expect(packageJSON.publishConfig.provenance).toBe(true);
 	expect(packageJSON.repository.url).toContain(
 		"github.com/dustin-ruetz/web-devdeps",
 	);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
 		"tsconfig.build.json",
 		"tsconfig.json"
 	],
+	"publishConfig": {
+		"provenance": true
+	},
 	"repository": {
 		"url": "git+ssh://git@github.com/dustin-ruetz/web-devdeps.git"
 	},


### PR DESCRIPTION
Excerpt from https://docs.npmjs.com/generating-provenance-statements:

> You can generate provenance statements for the packages you publish. This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.

Excerpt from https://github.com/semantic-release/npm#npm-provenance-on-github-actions:

> For package provenance to be signed on the GitHub Actions CI the following permission is required to be enabled on the job:
> 
> ```yaml
> permissions:
>   id-token: write # to enable use of OIDC for npm provenance