### PR TITLE
fix(config/eslint-plugins/jsdoc): remove 'check-indentation' rule

### DIFF
--- a/src/config/eslint-plugins/jsdoc.ts
+++ b/src/config/eslint-plugins/jsdoc.ts
@@ -19,12 +19,6 @@ export const makeJSDocPlugin = (hasTSConfigFile: boolean) =>
 			},
 			// https://github.com/gajus/eslint-plugin-jsdoc#rules
 			rules: {
-				"jsdoc/check-indentation": [
-					"error",
-					// Exclude tags where arbitrary indentation is helpful, i.e. for tags that often have a
-					// lengthy amount of content and are made more readable when broken out onto new lines.
-					{excludeTags: ["description", "example", "todo"]},
-				],
 				"jsdoc/check-line-alignment": "error",
 				"jsdoc/informative-docs": "error",
 				"jsdoc/require-asterisk-prefix": "error",

--- a/src/config/semantic-release.config.test.ts
+++ b/src/config/semantic-release.config.test.ts
@@ -7,7 +7,7 @@ test("it exports a configuration object and the most important config options ar
 
 	expect(semanticReleaseConfig.branches).toStrictEqual([
 		"main",
-		{name: "rc-", prerelease: true},
+		{name: "rc/*", prerelease: true},
 	]);
 
 	expect(semanticReleaseConfig.plugins).toStrictEqual([

--- a/src/config/semantic-release.config.test.ts
+++ b/src/config/semantic-release.config.test.ts
@@ -7,7 +7,7 @@ test("it exports a configuration object and the most important config options ar
 
 	expect(semanticReleaseConfig.branches).toStrictEqual([
 		"main",
-		{name: "test-*", prerelease: true},
+		{name: "!main", prerelease: "rc"},
 	]);
 
 	expect(semanticReleaseConfig.plugins).toStrictEqual([

--- a/src/config/semantic-release.config.test.ts
+++ b/src/config/semantic-release.config.test.ts
@@ -7,7 +7,7 @@ test("it exports a configuration object and the most important config options ar
 
 	expect(semanticReleaseConfig.branches).toStrictEqual([
 		"main",
-		{name: "!main", prerelease: "rc"},
+		{name: "rc-", prerelease: true},
 	]);
 
 	expect(semanticReleaseConfig.plugins).toStrictEqual([

--- a/src/config/semantic-release.config.ts
+++ b/src/config/semantic-release.config.ts
@@ -8,9 +8,10 @@ import type {Options} from "semantic-release";
 export const makeSemanticReleaseConfig = (): Options => ({
 	branches: [
 		"main",
-		// Publish pre-release package versions on branches beginning with the `test-` prefix.
-		// https://www.benmvp.com/blog/create-one-off-releases-semantic-release/
-		{name: "test-*", prerelease: true},
+		// - Allow for release candidate (`rc`) package versions to be published by manually triggering
+		//   the `release` GitHub Actions workflow from any branch that is not `main`.
+		// - Adapted from https://www.benmvp.com/blog/create-one-off-releases-semantic-release/
+		{name: "!main", prerelease: "rc"},
 	],
 	plugins: [
 		"@semantic-release/commit-analyzer",

--- a/src/config/semantic-release.config.ts
+++ b/src/config/semantic-release.config.ts
@@ -8,9 +8,9 @@ import type {Options} from "semantic-release";
 export const makeSemanticReleaseConfig = (): Options => ({
 	branches: [
 		"main",
-		// - Publish release candidate package versions on branches beginning with the `rc-` prefix.
+		// - Publish release candidate package versions on branches beginning with the `rc/` prefix.
 		// - Adapted from https://www.benmvp.com/blog/create-one-off-releases-semantic-release/
-		{name: "rc-", prerelease: true},
+		{name: "rc/*", prerelease: true},
 	],
 	plugins: [
 		"@semantic-release/commit-analyzer",

--- a/src/config/semantic-release.config.ts
+++ b/src/config/semantic-release.config.ts
@@ -8,10 +8,9 @@ import type {Options} from "semantic-release";
 export const makeSemanticReleaseConfig = (): Options => ({
 	branches: [
 		"main",
-		// - Allow for release candidate (`rc`) package versions to be published by manually triggering
-		//   the `release` GitHub Actions workflow from any branch that is not `main`.
+		// - Publish release candidate package versions on branches beginning with the `rc-` prefix.
 		// - Adapted from https://www.benmvp.com/blog/create-one-off-releases-semantic-release/
-		{name: "!main", prerelease: "rc"},
+		{name: "rc-", prerelease: true},
 	],
 	plugins: [
 		"@semantic-release/commit-analyzer",


### PR DESCRIPTION
The `jsdoc/check-indentation` rule isn't that helpful and there are times where arbitrary indentation in comments is useful, so this PR removes the rule in order to prevent it from raising ESLint errors.