### PR TITLE
fix(config/eslint-plugins/jsdoc): remove `check-indentation` rule

### DIFF
--- a/src/config/eslint-plugins/jsdoc.ts
+++ b/src/config/eslint-plugins/jsdoc.ts
@@ -19,12 +19,6 @@ export const makeJSDocPlugin = (hasTSConfigFile: boolean) =>
 			},
 			// https://github.com/gajus/eslint-plugin-jsdoc#rules
 			rules: {
-				"jsdoc/check-indentation": [
-					"error",
-					// Exclude tags where arbitrary indentation is helpful, i.e. for tags that often have a
-					// lengthy amount of content and are made more readable when broken out onto new lines.
-					{excludeTags: ["description", "example", "todo"]},
-				],
 				"jsdoc/check-line-alignment": "error",
 				"jsdoc/informative-docs": "error",
 				"jsdoc/require-asterisk-prefix": "error",


### PR DESCRIPTION
The `jsdoc/check-indentation` rule isn't that helpful and there are times where arbitrary indentation in comments is useful, so this PR removes the rule to raise ESLint errors.