### PR TITLE
fix(config/eslint-plugins/jsdoc): remove `check-indentation` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [1.2.1-rc-remove-check-indentation-rule-from-eslint-plugin-jsdoc.1](https://github.com/dustin-ruetz/web-devdeps/compare/v1.2.0...v1.2.1-rc-remove-check-indentation-rule-from-eslint-plugin-jsdoc.1) (2025-01-09)
+
+### Bug Fixes
+
+* **config/eslint-plugins/jsdoc:** remove 'check-indentation' rule ([c3289fc](https://github.com/dustin-ruetz/web-devdeps/commit/c3289fc3344ab94ffc37dad57215335a1b3ca422))
+* **config/semantic-release:** use 'rc-' as the branch name prefix to publish prerelease verions ([a9b8e74](https://github.com/dustin-ruetz/web-devdeps/commit/a9b8e7497fbdedd12eeb84e26feb05a1ff7f27c7))
+
 ## [1.2.0](https://github.com/dustin-ruetz/web-devdeps/compare/v1.1.1...v1.2.0) (2025-01-08)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "web-devdeps",
-	"version": "1.2.0",
+	"version": "1.2.1-rc-remove-check-indentation-rule-from-eslint-plugin-jsdoc.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "web-devdeps",
-			"version": "1.2.0",
+			"version": "1.2.1-rc-remove-check-indentation-rule-from-eslint-plugin-jsdoc.1",
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/cli": "19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web-devdeps",
-	"version": "1.2.0",
+	"version": "1.2.1-rc-remove-check-indentation-rule-from-eslint-plugin-jsdoc.1",
 	"description": "Package that provides development dependencies for other web projects (both browser- and Node.js-based) to consume.",
 	"main": "./lib/exports.js",
 	"scripts": {

--- a/src/config/eslint-plugins/jsdoc.ts
+++ b/src/config/eslint-plugins/jsdoc.ts
@@ -19,12 +19,6 @@ export const makeJSDocPlugin = (hasTSConfigFile: boolean) =>
 			},
 			// https://github.com/gajus/eslint-plugin-jsdoc#rules
 			rules: {
-				"jsdoc/check-indentation": [
-					"error",
-					// Exclude tags where arbitrary indentation is helpful, i.e. for tags that often have a
-					// lengthy amount of content and are made more readable when broken out onto new lines.
-					{excludeTags: ["description", "example", "todo"]},
-				],
 				"jsdoc/check-line-alignment": "error",
 				"jsdoc/informative-docs": "error",
 				"jsdoc/require-asterisk-prefix": "error",


### PR DESCRIPTION
The `jsdoc/check-indentation` rule isn't that helpful and there are times where arbitrary indentation in comments is useful, so this PR removes the rule in order to prevent it from raising ESLint errors.