### PR TITLE
feat: enable rewriting of relative import extensions

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 import {readdir} from "node:fs/promises";
-import {packageName} from "../src/constants.js";
+import {packageName} from "../src/constants.ts";
 import packageJSON from "../package.json" with {type: "json"};
 import packageLockJSON from "../package-lock.json" with {type: "json"};
 

--- a/__tests__/tsconfigJSON.test.ts
+++ b/__tests__/tsconfigJSON.test.ts
@@ -9,8 +9,8 @@ test("it is a configuration object and the most important config options are cor
 
 	const {compilerOptions} = tsconfigJSON;
 	expect(compilerOptions.module).toBe("NodeNext");
-	expect(compilerOptions.moduleResolution).toBe("NodeNext");
 	expect(compilerOptions.resolveJsonModule).toBe(true);
+	expect(compilerOptions.rewriteRelativeImportExtensions).toBe(true);
 	// Excerpt from https://www.typescriptlang.org/tsconfig#target on not using `"target": "esnext"`:
 	// > The special `ESNext` value refers to the highest version your version of TypeScript supports.
 	// > This setting should be used with caution, since it doesn't mean the same thing between

--- a/src/config/commitlint.config.test.ts
+++ b/src/config/commitlint.config.test.ts
@@ -1,4 +1,4 @@
-import {makeCommitlintConfig} from "./commitlint.config.js";
+import {makeCommitlintConfig} from "./commitlint.config.ts";
 
 test("it exports a configuration object and the most important config options are correct", () => {
 	const commitlintConfig = makeCommitlintConfig();

--- a/src/config/eslint-plugins/jest.test.ts
+++ b/src/config/eslint-plugins/jest.test.ts
@@ -1,4 +1,4 @@
-import {makeJestPlugin} from "./jest.js";
+import {makeJestPlugin} from "./jest.ts";
 
 describe("it exports a configuration array and the most important config options are correct", () => {
 	test("for the parts of the config that *are not* affected by conditional logic", () => {

--- a/src/config/eslint-plugins/jsdoc.test.ts
+++ b/src/config/eslint-plugins/jsdoc.test.ts
@@ -1,4 +1,4 @@
-import {makeJSDocPlugin} from "./jsdoc.js";
+import {makeJSDocPlugin} from "./jsdoc.ts";
 
 describe("it exports a configuration array and the most important config options are correct", () => {
 	test("for the parts of the config that *are not* affected by conditional logic", () => {

--- a/src/config/eslint-plugins/jsx-a11y.test.ts
+++ b/src/config/eslint-plugins/jsx-a11y.test.ts
@@ -1,4 +1,4 @@
-import {jsxA11yPlugin} from "./jsx-a11y.js";
+import {jsxA11yPlugin} from "./jsx-a11y.ts";
 
 test("it exports a configuration array and the most important config options are correct", () => {
 	expect(Array.isArray(jsxA11yPlugin)).toBe(true);

--- a/src/config/eslint-plugins/jsx-a11y.ts
+++ b/src/config/eslint-plugins/jsx-a11y.ts
@@ -1,6 +1,6 @@
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import typescripteslint from "typescript-eslint";
-import {reactFilesGlobPattern} from "./react-hooks.js";
+import {reactFilesGlobPattern} from "./react-hooks.ts";
 
 /**
  * @description Accessibility-specific linting rules for elements written in JSX syntax.

--- a/src/config/eslint-plugins/react-hooks.test.ts
+++ b/src/config/eslint-plugins/react-hooks.test.ts
@@ -1,4 +1,4 @@
-import {reactHooksPlugin} from "./react-hooks.js";
+import {reactHooksPlugin} from "./react-hooks.ts";
 
 test("it exports a configuration array and the most important config options are correct", () => {
 	expect(Array.isArray(reactHooksPlugin)).toBe(true);

--- a/src/config/eslint-plugins/typescript-eslint.test.ts
+++ b/src/config/eslint-plugins/typescript-eslint.test.ts
@@ -1,4 +1,4 @@
-import {typescripteslintPlugin} from "./typescript-eslint.js";
+import {typescripteslintPlugin} from "./typescript-eslint.ts";
 
 test("it exports a configuration array and the most important config options are correct", () => {
 	expect(Array.isArray(typescripteslintPlugin)).toBe(true);

--- a/src/config/eslint-plugins/typescript-eslint.ts
+++ b/src/config/eslint-plugins/typescript-eslint.ts
@@ -1,5 +1,5 @@
 import typescripteslint from "typescript-eslint";
-import {mockAndTestFilesGlobPattern} from "./jest.js";
+import {mockAndTestFilesGlobPattern} from "./jest.ts";
 
 /**
  * @description "**`typescript-eslint` enables ESLint to run on TypeScript code.** It brings in the best of

--- a/src/config/eslint.config.test.ts
+++ b/src/config/eslint.config.test.ts
@@ -1,8 +1,8 @@
 import type {TSESLint} from "@typescript-eslint/utils";
 import globals from "globals";
 import {access} from "node:fs/promises";
-import {dependsOnMock} from "../utils/dependsOn.mock.js";
-import {makeESLintConfig} from "./eslint.config.js";
+import {dependsOnMock} from "../utils/dependsOn.mock.ts";
+import {makeESLintConfig} from "./eslint.config.ts";
 
 jest.mock("node:fs/promises");
 const accessMock = jest.mocked(access);

--- a/src/config/eslint.config.ts
+++ b/src/config/eslint.config.ts
@@ -3,16 +3,16 @@ import eslintjs from "@eslint/js";
 import globals from "globals";
 import {access, constants} from "node:fs/promises";
 import typescripteslint, {type Config} from "typescript-eslint";
-import {dependsOn} from "../utils/dependsOn.js";
-import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.js";
+import {dependsOn} from "../utils/dependsOn.ts";
+import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.ts";
 import {
 	makeJestPlugin,
 	mockAndTestFilesGlobPattern,
-} from "./eslint-plugins/jest.js";
-import {makeJSDocPlugin} from "./eslint-plugins/jsdoc.js";
-import {jsxA11yPlugin} from "./eslint-plugins/jsx-a11y.js";
-import {reactHooksPlugin} from "./eslint-plugins/react-hooks.js";
-import {typescripteslintPlugin} from "./eslint-plugins/typescript-eslint.js";
+} from "./eslint-plugins/jest.ts";
+import {makeJSDocPlugin} from "./eslint-plugins/jsdoc.ts";
+import {jsxA11yPlugin} from "./eslint-plugins/jsx-a11y.ts";
+import {reactHooksPlugin} from "./eslint-plugins/react-hooks.ts";
+import {typescripteslintPlugin} from "./eslint-plugins/typescript-eslint.ts";
 
 /**
  * @description "ESLint statically analyzes your code to quickly find problems."
@@ -79,6 +79,7 @@ export const makeESLintConfig = async (): Promise<Config> => {
 			// https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options:
 			linterOptions: {
 				reportUnusedDisableDirectives: "error",
+				// reportUnusedInlineConfigs: "error",
 			},
 			rules: {
 				// https://eslint.org/docs/latest/rules/#possible-problems

--- a/src/config/jest-utils/binaryFile.transformer.test.ts
+++ b/src/config/jest-utils/binaryFile.transformer.test.ts
@@ -1,4 +1,4 @@
-import binaryFileTransformer from "./binaryFile.transformer.js";
+import binaryFileTransformer from "./binaryFile.transformer.ts";
 
 test('it transforms binary file paths into `module.exports = "name.extension"`', () => {
 	const sourceText = "";

--- a/src/config/jest-utils/svgFile.test.ts
+++ b/src/config/jest-utils/svgFile.test.ts
@@ -1,4 +1,4 @@
-import svgFileTransformer from "./svgFile.transformer.js";
+import svgFileTransformer from "./svgFile.transformer.ts";
 
 test('it transforms SVG files into `module.exports = "<svg>{...}</svg>"`', () => {
 	const sourceText = `

--- a/src/config/jest.config.test.ts
+++ b/src/config/jest.config.test.ts
@@ -1,6 +1,6 @@
-import {dependsOnMock} from "../utils/dependsOn.mock.js";
-import {getAbsoluteRepoRootPathMock} from "../utils/getAbsoluteRepoRootPath.mock.js";
-import {makeJestConfig} from "./jest.config.js";
+import {dependsOnMock} from "../utils/dependsOn.mock.ts";
+import {getAbsoluteRepoRootPathMock} from "../utils/getAbsoluteRepoRootPath.mock.ts";
+import {makeJestConfig} from "./jest.config.ts";
 
 afterEach(() => {
 	jest.clearAllMocks();

--- a/src/config/jest.config.ts
+++ b/src/config/jest.config.ts
@@ -1,9 +1,9 @@
 import type {Config} from "jest";
-import {dependsOn} from "../utils/dependsOn.js";
-import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.js";
-import {getIsWebDevdepsRepo} from "../utils/getIsWebDevdepsRepo.js";
-import {makeCachePath} from "../utils/makeCachePath.js";
-import {nodeModulesPackagePath} from "../constants.js";
+import {dependsOn} from "../utils/dependsOn.ts";
+import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.ts";
+import {getIsWebDevdepsRepo} from "../utils/getIsWebDevdepsRepo.ts";
+import {makeCachePath} from "../utils/makeCachePath.ts";
+import {nodeModulesPackagePath} from "../constants.ts";
 
 /**
  * @description "Jest is a delightful JavaScript testing framework with a focus on simplicity."

--- a/src/config/lint-staged.config.test.ts
+++ b/src/config/lint-staged.config.test.ts
@@ -1,5 +1,5 @@
 import type {Configuration} from "lint-staged";
-import {makeLintstagedConfig} from "./lint-staged.config.js";
+import {makeLintstagedConfig} from "./lint-staged.config.ts";
 
 test("it exports a configuration object", () => {
 	const lintstagedConfig = makeLintstagedConfig();

--- a/src/config/prettier-plugins/pug.test.ts
+++ b/src/config/prettier-plugins/pug.test.ts
@@ -1,4 +1,4 @@
-import {pugPrettierPlugin} from "./pug.js";
+import {pugPrettierPlugin} from "./pug.ts";
 
 test("it exports a configuration object, and the most important config options and plugin name are correct", () => {
 	expect(typeof pugPrettierPlugin).toBe("object");

--- a/src/config/prettier-plugins/xml.test.ts
+++ b/src/config/prettier-plugins/xml.test.ts
@@ -1,4 +1,4 @@
-import {xmlPrettierPlugin} from "./xml.js";
+import {xmlPrettierPlugin} from "./xml.ts";
 
 test("it exports a configuration object, and the most important config options and plugin name are correct", () => {
 	expect(typeof xmlPrettierPlugin).toBe("object");

--- a/src/config/prettier.config.test.ts
+++ b/src/config/prettier.config.test.ts
@@ -1,7 +1,7 @@
-import {dependsOnMock} from "../utils/dependsOn.mock.js";
-import {makePrettierConfig} from "./prettier.config.js";
-import {pugPrettierPlugin} from "./prettier-plugins/pug.js";
-import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
+import {dependsOnMock} from "../utils/dependsOn.mock.ts";
+import {makePrettierConfig} from "./prettier.config.ts";
+import {pugPrettierPlugin} from "./prettier-plugins/pug.ts";
+import {xmlPrettierPlugin} from "./prettier-plugins/xml.ts";
 
 test("it exports a configuration object and the most important config options are correct", async () => {
 	expect.hasAssertions();

--- a/src/config/prettier.config.ts
+++ b/src/config/prettier.config.ts
@@ -1,7 +1,7 @@
 import type {Config} from "prettier";
-import {dependsOn} from "../utils/dependsOn.js";
-import {pugPrettierPlugin} from "./prettier-plugins/pug.js";
-import {xmlPrettierPlugin} from "./prettier-plugins/xml.js";
+import {dependsOn} from "../utils/dependsOn.ts";
+import {pugPrettierPlugin} from "./prettier-plugins/pug.ts";
+import {xmlPrettierPlugin} from "./prettier-plugins/xml.ts";
 
 /**
  * @description "Prettier is an opinionated code formatter. It removes all original styling

--- a/src/config/semantic-release.config.test.ts
+++ b/src/config/semantic-release.config.test.ts
@@ -1,4 +1,4 @@
-import {makeSemanticReleaseConfig} from "./semantic-release.config.js";
+import {makeSemanticReleaseConfig} from "./semantic-release.config.ts";
 
 test("it exports a configuration object and the most important config options are correct", () => {
 	const semanticReleaseConfig = makeSemanticReleaseConfig();

--- a/src/config/stylelint.config.test.ts
+++ b/src/config/stylelint.config.test.ts
@@ -1,5 +1,5 @@
-import {dependsOnMock} from "../utils/dependsOn.mock.js";
-import {makeStylelintConfig} from "./stylelint.config.js";
+import {dependsOnMock} from "../utils/dependsOn.mock.ts";
+import {makeStylelintConfig} from "./stylelint.config.ts";
 
 describe("it exports a configuration object and the most important config options are correct", () => {
 	test("for the parts of the config that *are not* affected by conditional logic", async () => {

--- a/src/config/stylelint.config.ts
+++ b/src/config/stylelint.config.ts
@@ -1,5 +1,5 @@
 import type {Config} from "stylelint";
-import {dependsOn} from "../utils/dependsOn.js";
+import {dependsOn} from "../utils/dependsOn.ts";
 
 /**
  * @description "A mighty CSS linter that helps you avoid errors and enforce conventions."

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,4 +1,4 @@
-import {nodeModulesPackagePath, packageName} from "./constants.js";
+import {nodeModulesPackagePath, packageName} from "./constants.ts";
 
 test("the constants are set to the correct values", () => {
 	expect(packageName).toBe("web-devdeps");

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -6,7 +6,7 @@ import {
 	makePrettierConfig,
 	makeSemanticReleaseConfig,
 	makeStylelintConfig,
-} from "./exports.js";
+} from "./exports.ts";
 
 test("all of the module's exports are available from the primary `exports` file", () => {
 	expect(typeof makeCommitlintConfig).toBe("function");

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,10 +1,10 @@
 // - This is the main file for exporting everything that consuming repos can use from the `web-devdeps` package.
 // - This file's compiled `lib/exports.js` path is the value of the `main` field of the `package.json` file.
 
-export {makeCommitlintConfig} from "./config/commitlint.config.js";
-export {makeESLintConfig} from "./config/eslint.config.js";
-export {makeJestConfig} from "./config/jest.config.js";
-export {makeLintstagedConfig} from "./config/lint-staged.config.js";
-export {makePrettierConfig} from "./config/prettier.config.js";
-export {makeSemanticReleaseConfig} from "./config/semantic-release.config.js";
-export {makeStylelintConfig} from "./config/stylelint.config.js";
+export {makeCommitlintConfig} from "./config/commitlint.config.ts";
+export {makeESLintConfig} from "./config/eslint.config.ts";
+export {makeJestConfig} from "./config/jest.config.ts";
+export {makeLintstagedConfig} from "./config/lint-staged.config.ts";
+export {makePrettierConfig} from "./config/prettier.config.ts";
+export {makeSemanticReleaseConfig} from "./config/semantic-release.config.ts";
+export {makeStylelintConfig} from "./config/stylelint.config.ts";

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,9 @@
-import {initRepo, logInitRepoHelpText} from "./scripts/initRepo.js";
-import {runCLI} from "./scripts/runCLI.js";
-import {runScript} from "./index.js";
+import {initRepo, logInitRepoHelpText} from "./scripts/initRepo.ts";
+import {runCLI} from "./scripts/runCLI.ts";
+import {runScript} from "./index.ts";
 
-jest.mock("./scripts/initRepo.js");
-jest.mock("./scripts/runCLI.js");
+jest.mock("./scripts/initRepo.ts");
+jest.mock("./scripts/runCLI.ts");
 
 afterEach(() => {
 	jest.clearAllMocks();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import {initRepo, logInitRepoHelpText} from "./scripts/initRepo.js";
-import {runCLI} from "./scripts/runCLI.js";
-import {CustomError} from "./utils/CustomError.js";
+import {initRepo, logInitRepoHelpText} from "./scripts/initRepo.ts";
+import {runCLI} from "./scripts/runCLI.ts";
+import {CustomError} from "./utils/CustomError.ts";
 
 /**
  *

--- a/src/scripts/helpers/getRootPaths.test.ts
+++ b/src/scripts/helpers/getRootPaths.test.ts
@@ -1,5 +1,5 @@
-import {getAbsoluteRepoRootPathMock} from "../../utils/getAbsoluteRepoRootPath.mock.js";
-import {getRootPaths} from "./getRootPaths.js";
+import {getAbsoluteRepoRootPathMock} from "../../utils/getAbsoluteRepoRootPath.mock.ts";
+import {getRootPaths} from "./getRootPaths.ts";
 
 afterEach(() => {
 	jest.clearAllMocks();

--- a/src/scripts/helpers/getRootPaths.ts
+++ b/src/scripts/helpers/getRootPaths.ts
@@ -1,6 +1,6 @@
-import {getAbsoluteRepoRootPath} from "../../utils/getAbsoluteRepoRootPath.js";
-import {getIsWebDevdepsRepo} from "../../utils/getIsWebDevdepsRepo.js";
-import {nodeModulesPackagePath} from "../../constants.js";
+import {getAbsoluteRepoRootPath} from "../../utils/getAbsoluteRepoRootPath.ts";
+import {getIsWebDevdepsRepo} from "../../utils/getIsWebDevdepsRepo.ts";
+import {nodeModulesPackagePath} from "../../constants.ts";
 
 /**
  * @description Determines the root paths when running the `init-repo` script and its associated helper functions.

--- a/src/scripts/helpers/initRepoHelpers.test.ts
+++ b/src/scripts/helpers/initRepoHelpers.test.ts
@@ -12,7 +12,7 @@ import {
 	writeTsConfig,
 	writeTsConfigBuild,
 	writeVsCodeSettings,
-} from "./initRepoHelpers.js";
+} from "./initRepoHelpers.ts";
 
 jest.mock("node:fs/promises");
 const readdirMock = jest.mocked(readdir);

--- a/src/scripts/helpers/initRepoHelpers.ts
+++ b/src/scripts/helpers/initRepoHelpers.ts
@@ -1,7 +1,7 @@
 import {mkdir, readdir, readFile, writeFile} from "node:fs/promises";
-import type {PackageJsonTypes} from "../../types.d.js";
-import {nodeModulesPackagePath, packageName} from "../../constants.js";
-import {getRootPaths} from "./getRootPaths.js";
+import type {PackageJsonTypes} from "../../types.d.ts";
+import {nodeModulesPackagePath, packageName} from "../../constants.ts";
+import {getRootPaths} from "./getRootPaths.ts";
 
 const rootPathToReadFrom = getRootPaths().readFrom;
 const rootPathToWriteTo = getRootPaths().writeTo;

--- a/src/scripts/helpers/semVerRegExp.test.ts
+++ b/src/scripts/helpers/semVerRegExp.test.ts
@@ -1,4 +1,4 @@
-import {semVerRegExp} from "./semVerRegExp.js";
+import {semVerRegExp} from "./semVerRegExp.ts";
 
 describe("it correctly identifies matches for the semantic version format", () => {
 	test.each`

--- a/src/scripts/initRepo.test.ts
+++ b/src/scripts/initRepo.test.ts
@@ -12,13 +12,13 @@ import {
 	writeTsConfig,
 	writeTsConfigBuild,
 	writeVsCodeSettings,
-} from "./helpers/initRepoHelpers.js";
-import {initRepo, logInitRepoHelpText} from "./initRepo.js";
+} from "./helpers/initRepoHelpers.ts";
+import {initRepo, logInitRepoHelpText} from "./initRepo.ts";
 
 jest.mock("node:fs/promises");
 const readFileMock = jest.mocked(readFile);
 
-jest.mock("./helpers/initRepoHelpers.js");
+jest.mock("./helpers/initRepoHelpers.ts");
 
 const testRepoName = "repo-name";
 /**

--- a/src/scripts/initRepo.ts
+++ b/src/scripts/initRepo.ts
@@ -6,9 +6,9 @@
 //    ```
 
 import {readFile} from "node:fs/promises";
-import {CustomError} from "../utils/CustomError.js";
-import {packageName} from "../constants.js";
-import {getRootPaths} from "./helpers/getRootPaths.js";
+import {CustomError} from "../utils/CustomError.ts";
+import {packageName} from "../constants.ts";
+import {getRootPaths} from "./helpers/getRootPaths.ts";
 import {
 	writeGitAttributes,
 	writeGitHooks,
@@ -22,8 +22,8 @@ import {
 	writeTsConfig,
 	writeTsConfigBuild,
 	writeVsCodeSettings,
-} from "./helpers/initRepoHelpers.js";
-import {semVerRegExp} from "./helpers/semVerRegExp.js";
+} from "./helpers/initRepoHelpers.ts";
+import {semVerRegExp} from "./helpers/semVerRegExp.ts";
 
 /**
  * @description Defines the information about the arguments for running the `init-repo` script.

--- a/src/scripts/runCLI.test.ts
+++ b/src/scripts/runCLI.test.ts
@@ -1,6 +1,6 @@
 import {spawn} from "node:child_process";
-import {getAbsoluteRepoRootPathMock} from "../utils/getAbsoluteRepoRootPath.mock.js";
-import {type cli, runCLI} from "./runCLI.js";
+import {getAbsoluteRepoRootPathMock} from "../utils/getAbsoluteRepoRootPath.mock.ts";
+import {type cli, runCLI} from "./runCLI.ts";
 
 jest.mock("node:child_process", () => ({
 	spawn: jest.fn(() => ({

--- a/src/scripts/runCLI.ts
+++ b/src/scripts/runCLI.ts
@@ -1,8 +1,8 @@
 import {spawn} from "node:child_process";
-import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.js";
-import {getIsWebDevdepsRepo} from "../utils/getIsWebDevdepsRepo.js";
-import {makeCachePath} from "../utils/makeCachePath.js";
-import {nodeModulesPackagePath} from "../constants.js";
+import {getAbsoluteRepoRootPath} from "../utils/getAbsoluteRepoRootPath.ts";
+import {getIsWebDevdepsRepo} from "../utils/getIsWebDevdepsRepo.ts";
+import {makeCachePath} from "../utils/makeCachePath.ts";
+import {nodeModulesPackagePath} from "../constants.ts";
 
 export type cli =
 	| "commitlint"

--- a/src/utils/CustomError.test.ts
+++ b/src/utils/CustomError.test.ts
@@ -1,4 +1,4 @@
-import {CustomError} from "./CustomError.js";
+import {CustomError} from "./CustomError.ts";
 
 const errorName = "CustomError";
 const errorMessage = "custom error";

--- a/src/utils/dependsOn.mock.ts
+++ b/src/utils/dependsOn.mock.ts
@@ -1,6 +1,6 @@
-import {dependsOn} from "./dependsOn.js";
+import {dependsOn} from "./dependsOn.ts";
 
-jest.mock("./dependsOn.js", () => ({
+jest.mock("./dependsOn.ts", () => ({
 	dependsOn: jest.fn(),
 }));
 

--- a/src/utils/dependsOn.test.ts
+++ b/src/utils/dependsOn.test.ts
@@ -1,8 +1,8 @@
 import {readFile} from "node:fs/promises";
 // Ideally the following two import statements would be in alphabetical order, but since
 // `getAbsoluteRepoRootPath` is imported in `dependsOn`, its mock must be imported first.
-import {getAbsoluteRepoRootPathMock} from "./getAbsoluteRepoRootPath.mock.js";
-import {dependsOn} from "./dependsOn.js";
+import {getAbsoluteRepoRootPathMock} from "./getAbsoluteRepoRootPath.mock.ts";
+import {dependsOn} from "./dependsOn.ts";
 
 jest.mock("node:fs/promises", () => ({
 	readFile: jest.fn(),

--- a/src/utils/dependsOn.ts
+++ b/src/utils/dependsOn.ts
@@ -1,7 +1,7 @@
 import {readFile} from "node:fs/promises";
-import type {PackageJsonTypes} from "../types.d.js";
-import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.js";
-import {CustomError} from "./CustomError.js";
+import type {PackageJsonTypes} from "../types.d.ts";
+import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.ts";
+import {CustomError} from "./CustomError.ts";
 
 /**
  * @description Given a list of dependencies, check the repository's `package.json` file

--- a/src/utils/getAbsoluteRepoRootPath.mock.ts
+++ b/src/utils/getAbsoluteRepoRootPath.mock.ts
@@ -1,6 +1,6 @@
-import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.js";
+import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.ts";
 
-jest.mock("./getAbsoluteRepoRootPath.js", () => ({
+jest.mock("./getAbsoluteRepoRootPath.ts", () => ({
 	// The function returns a string, so have the mock return an empty string by default.
 	getAbsoluteRepoRootPath: jest.fn(() => ""),
 }));

--- a/src/utils/getAbsoluteRepoRootPath.test.ts
+++ b/src/utils/getAbsoluteRepoRootPath.test.ts
@@ -1,5 +1,5 @@
 import {fileURLToPath} from "node:url";
-import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.js";
+import {getAbsoluteRepoRootPath} from "./getAbsoluteRepoRootPath.ts";
 
 jest.mock("node:url", () => ({
 	fileURLToPath: jest.fn(),

--- a/src/utils/getAbsoluteRepoRootPath.ts
+++ b/src/utils/getAbsoluteRepoRootPath.ts
@@ -1,6 +1,6 @@
 import {fileURLToPath} from "node:url";
-import {nodeModulesPackagePath, packageName} from "../constants.js";
-import {CustomError} from "./CustomError.js";
+import {nodeModulesPackagePath, packageName} from "../constants.ts";
+import {CustomError} from "./CustomError.ts";
 
 /**
  * The purpose of this function is to provide a more robust alternative to `process.cwd()`. As per

--- a/src/utils/getIsWebDevdepsRepo.test.ts
+++ b/src/utils/getIsWebDevdepsRepo.test.ts
@@ -1,4 +1,4 @@
-import {getIsWebDevdepsRepo} from "./getIsWebDevdepsRepo.js";
+import {getIsWebDevdepsRepo} from "./getIsWebDevdepsRepo.ts";
 
 describe("it correctly identifies whether or not the passed path represents the `web-devdeps` repo", () => {
 	test.each`

--- a/src/utils/getIsWebDevdepsRepo.ts
+++ b/src/utils/getIsWebDevdepsRepo.ts
@@ -1,4 +1,4 @@
-import {packageName} from "../constants.js";
+import {packageName} from "../constants.ts";
 
 /**
  * @description Given a path, determine whether or not it's this `web-devdeps` repository.

--- a/src/utils/makeCachePath.test.ts
+++ b/src/utils/makeCachePath.test.ts
@@ -1,4 +1,4 @@
-import {makeCachePath} from "./makeCachePath.js";
+import {makeCachePath} from "./makeCachePath.ts";
 
 test("it makes a cache folder", () => {
 	expect(makeCachePath(".foldercache/")).toBe(".caches/.foldercache/");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
 	"compilerOptions": {
 		"jsx": "react",
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
 		"noUncheckedSideEffectImports": true,
 		"resolveJsonModule": true,
+		"rewriteRelativeImportExtensions": true,
 		"target": "ES2023",
 		"verbatimModuleSyntax": true
 	}


### PR DESCRIPTION
- Resolves https://github.com/dustin-ruetz/web-devdeps/issues/76
- Enables the `compilerOptions.rewriteRelativeImportExtensions` setting in `tsconfig.json`.
- Refactors the file extensions (from `*.js` to `*.ts` in all import paths and `jest.mock` calls.